### PR TITLE
Enable intl extension by default

### DIFF
--- a/php7.rb
+++ b/php7.rb
@@ -105,6 +105,7 @@ class Php7 < Formula
       "--enable-sysvshm",
       "--enable-wddx",
       "--enable-zip",
+      "--enable-intl",
       "--with-freetype-dir=#{Formula["freetype"].opt_prefix}",
       "--with-gd",
       "--with-gettext=#{Formula["gettext"].opt_prefix}",


### PR DESCRIPTION
This extension is used a lot, so I thought it might be good to enable it by default.
